### PR TITLE
Performance improvements Rust

### DIFF
--- a/rust-suduko-solver/src/main.rs
+++ b/rust-suduko-solver/src/main.rs
@@ -2,35 +2,36 @@ use std::time::Instant;
 
 use itertools::Itertools;
 
-use crate::sudoku_solver::sudoku_solver::solve;
+use crate::sudoku_solver::{solve, SudokuBoard};
 mod read_lines;
 mod sudoku_solver;
 
 fn main() {
-  let now = Instant::now();
-  let file_name = "../data-files/puzzles.txt";
+    let now = Instant::now();
+    let file_name = "../data-files/puzzles.txt";
 
-  if let Ok(puzzles) = read_lines::read_lines(file_name) {
-    for full_puzzle in puzzles {
-      if let Ok(line) = full_puzzle {
-        let mut puzzle: [[u32; 9]; 9] = Default::default();
+    if let Ok(puzzles) = read_lines::read_lines(file_name) {
+        for line in puzzles.flatten() {
+            let mut puzzle: SudokuBoard = Default::default();
 
-        // Create puzzle
-        for (row_index, row) in line.chars().chunks(9).into_iter().enumerate() {
-          for (column_index, value) in row.enumerate() {
-            match value.to_digit(10) {
-              None => panic!("Unknown digit: {value}"),
-              Some(x) => puzzle[row_index][column_index] = x,
-            };
-          }
+            // Create puzzle
+            for (row_index, row) in line.chars().chunks(9).into_iter().enumerate() {
+                for (column_index, value) in row.enumerate() {
+                    match value.to_digit(10) {
+                        None => panic!("Unknown digit: {value}"),
+                        Some(x) => {
+                            puzzle[row_index][column_index] =
+                                u8::try_from(x).expect("Invalid digit")
+                        }
+                    };
+                }
+            }
+
+            println!("{:?}", solve(puzzle));
         }
-
-        println!("{:?}", solve(puzzle));
-      }
     }
-  }
 
-  // Convert to MS
-  let elapsed = now.elapsed().as_secs_f64() * 1000f64;
-  println!("Elapsed: {:.2?}", elapsed);
+    // Convert to MS
+    let elapsed = now.elapsed().as_secs_f64() * 1000f64;
+    println!("Elapsed: {:.2?}", elapsed);
 }

--- a/rust-suduko-solver/src/main.rs
+++ b/rust-suduko-solver/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
                 }
             }
 
-            println!("{:?}", solve(puzzle));
+            println!("{:?}", solve(&mut puzzle));
         }
     }
 

--- a/rust-suduko-solver/src/read_lines.rs
+++ b/rust-suduko-solver/src/read_lines.rs
@@ -1,4 +1,8 @@
-use std::{io::{self, BufRead}, path::Path, fs};
+use std::{
+    fs,
+    io::{self, BufRead},
+    path::Path,
+};
 
 // Source: https://doc.rust-lang.org/rust-by-example/std_misc/file/read_lines.html
 pub fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<fs::File>>>

--- a/rust-suduko-solver/src/sudoku_solver.rs
+++ b/rust-suduko-solver/src/sudoku_solver.rs
@@ -63,20 +63,20 @@ fn get_options(board: &SudokuBoard, row: usize, column: usize) -> [u8; 9] {
 }
 
 #[inline]
-pub fn solve(mut board: SudokuBoard) -> SudokuBoard {
-    let [row, column] = next_empty_cell(&board);
+pub fn solve(board: &mut SudokuBoard) -> &SudokuBoard {
+    let [row, column] = next_empty_cell(board);
 
     if [row, column] == [10, 10] {
         return board;
     }
 
-    for option in get_options(&board, row, column)
+    for option in get_options(board, row, column)
         .into_iter()
         .take_while(|&x| x != 0)
     {
         board[row][column] = option;
-        board = solve(board);
-        if is_solved(&board) {
+        solve(board);
+        if is_solved(board) {
             return board;
         }
     }

--- a/rust-suduko-solver/src/sudoku_solver.rs
+++ b/rust-suduko-solver/src/sudoku_solver.rs
@@ -1,80 +1,85 @@
 // https://blog.cloudboost.io/sudoku-solver-rust-recursive-implementation-backtracking-technique-fecf87d0477
 
-pub mod sudoku_solver {
-    pub fn valid(board: [[u32; 9]; 9], row: usize, column: usize, guess: u32) -> bool {
-        // Check row and column for the guess
-        for x in 0..9 {
-            if board[row][x] == guess || board[x][column] == guess {
+pub type SudokuBoard = [[u8; 9]; 9];
+
+#[inline]
+pub fn valid(board: &SudokuBoard, row: usize, column: usize, guess: u8) -> bool {
+    // Check row and column for the guess
+    for x in 0..9 {
+        if board[row][x] == guess || board[x][column] == guess {
+            return false;
+        }
+    }
+
+    let x_index = row / 3 * 3;
+    let y_index = column / 3 * 3;
+
+    // Check the containing square for the guess
+    for x in 0..3 {
+        for y in 0..3 {
+            if board[x_index + x][y_index + y] == guess {
                 return false;
             }
         }
+    }
 
-        let x_index = row / 3 * 3;
-        let y_index = column / 3 * 3;
+    true
+}
 
-        // Check the containing square for the guess
-        for x in 0..3 {
-            for y in 0..3 {
-                if board[x_index + x][y_index + y] == guess {
-                    return false;
-                }
+// Consider puzzle solved when an empty cell cannot be found
+#[inline]
+fn is_solved(board: &SudokuBoard) -> bool {
+    next_empty_cell(board) == [10, 10]
+}
+
+// Find the next empty cell on the board
+#[inline]
+fn next_empty_cell(board: &SudokuBoard) -> [usize; 2] {
+    for (row, row_array) in board.iter().enumerate() {
+        for (column, &item) in row_array.iter().enumerate() {
+            if item == 0 {
+                return [row, column];
             }
         }
-
-        true
     }
 
-    // Consider puzzle solved when an empty cell cannot be found
-    fn is_solved(board: [[u32; 9]; 9]) -> bool {
-        next_empty_cell(board) == [10, 10]
-    }
+    [10, 10]
+}
 
-    // Find the next empty cell on the board
-    fn next_empty_cell(board: [[u32; 9]; 9]) -> [usize; 2] {
-        for row in 0..9 {
-            for column in 0..9 {
-                if board[row][column] == 0 {
-                    return [row, column];
-                }
-            }
+// Find all valid options for a position in the puzzle
+#[inline]
+fn get_options(board: &SudokuBoard, row: usize, column: usize) -> [u8; 9] {
+    let mut result = [0_u8; 9];
+    let mut index = 0;
+
+    for option in 1..10 {
+        if valid(board, row, column, option) {
+            result[index] = option;
+            index += 1;
         }
-
-        [10, 10]
     }
 
-    // Find all valid options for a position in the puzzle
-    fn get_options(board: [[u32; 9]; 9], row: usize, column: usize) -> Vec<u32> {
-        let mut result = vec![];
+    result
+}
 
-        for option in 1..10 {
-            if valid(board, row, column, option) {
-                result.push(option);
-            }
-        }
+#[inline]
+pub fn solve(mut board: SudokuBoard) -> SudokuBoard {
+    let [row, column] = next_empty_cell(&board);
 
-        result
+    if [row, column] == [10, 10] {
+        return board;
     }
 
-    pub fn solve(board: [[u32; 9]; 9]) -> [[u32; 9]; 9] {
-        let mut result = board;
-
-        let empty_cell: [usize; 2] = next_empty_cell(board);
-
-        if is_solved(board) {
-            return result;
+    for option in get_options(&board, row, column)
+        .into_iter()
+        .take_while(|&x| x != 0)
+    {
+        board[row][column] = option;
+        board = solve(board);
+        if is_solved(&board) {
+            return board;
         }
-
-        let row: usize = empty_cell[0];
-        let column: usize = empty_cell[1];
-
-        for option in get_options(board, row, column) {
-            result[row][column] = option;
-            result = solve(result);
-            if is_solved(result) {
-                return result;
-            }
-        }
-        result = board;
-        return result;
     }
+    board[row][column] = 0;
+    board
 }


### PR DESCRIPTION
- Ran cargo fmt
- Ran cargo clippy
- Used references where ok
- Added #[inline]
- Removed Vec allocations
- Used u8 instead of u32

Result: -65.8% in time used

Before: Elapsed: 37420.13
After: Elapsed: 12778.32